### PR TITLE
Make Dependabot leave ruby at 2.6.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
 
   - package-ecosystem: "docker"
     directory: "/"
+    ignore:
+      - dependency-name: "ruby"
+        versions:
+          - "2.7.x"
+          - "3.x"
     schedule:
       interval: "daily"
       time: "06:00"


### PR DESCRIPTION
Based on https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/enabling-and-disabling-version-updates#disabling-dependabot-version-updates, let's see if it works.