### PR TITLE
Prevent access to uninitialized variable

### DIFF
--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -83,7 +83,7 @@ module Fluent
             record.delete('service')
           end
           metadata = get_pod_metadata(namespace_name, pod_name)
-          service = @pods_to_services[pod_name]
+          service = @pods_to_services[pod_name] unless @pods_to_services.nil?
           metadata['service'] = {'service' => service.sort!.join('_')} if !(service.nil? || service.empty?)
 
           if @data_type == 'metrics' && (record['node'].nil? || record['node'] == "")

--- a/fluent-plugin-enhance-k8s-metadata/test/plugin/test_filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/test/plugin/test_filter_enhance_k8s_metadata.rb
@@ -67,7 +67,6 @@ class EnhanceK8sMetadataFilterTest < Test::Unit::TestCase
 
   def create_driver(conf)
     driver = Fluent::Test::Driver::Filter.new(Fluent::Plugin::EnhanceK8sMetadataFilter).configure(conf).instance
-    driver.instance_variable_set(:@pods_to_services, @pods_to_services)
     driver
   end
 


### PR DESCRIPTION
The `@pods_to_services` variable is being initialized in another thread https://github.com/SumoLogic/sumologic-kubernetes-fluentd/blob/main/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/service_monitor.rb#L52. We need to make sure `@pods_to_services` is not accessed until it's properly initialized.