### PR TITLE
 Make connections to k8s API server persistent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,13 @@ RUN gem install \
         fluentd:1.12.0 \
         concurrent-ruby:1.1.5 \
         google-protobuf:3.9.2 \
-        kubeclient:4.9.1 \
         lru_redux:1.1.0 \
-        snappy:0.0.17
+        net-http-persistent:3.1.0 \
+        snappy:0.0.17 \
+        specific_install:0.3.5
+
+# Use unreleased Kubeclient version with persistent HTTP connections.
+RUN gem specific_install https://github.com/abonas/kubeclient --ref 3267dc3fd02c49e3b19f1210ff7cb84c3b2a4478
 
 # FluentD plugins to allow customers to forward data if needed to various cloud providers
 RUN gem install \

--- a/fluent-plugin-enhance-k8s-metadata/Gemfile
+++ b/fluent-plugin-enhance-k8s-metadata/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
+gem 'kubeclient', git: 'https://github.com/abonas/kubeclient/', ref: '3267dc3fd02c49e3b19f1210ff7cb84c3b2a4478' 
+
 gemspec

--- a/fluent-plugin-enhance-k8s-metadata/Gemfile.lock
+++ b/fluent-plugin-enhance-k8s-metadata/Gemfile.lock
@@ -1,11 +1,23 @@
+GIT
+  remote: https://github.com/abonas/kubeclient/
+  revision: 3267dc3fd02c49e3b19f1210ff7cb84c3b2a4478
+  ref: 3267dc3fd02c49e3b19f1210ff7cb84c3b2a4478
+  specs:
+    kubeclient (4.9.1)
+      faraday (~> 1.1)
+      faraday_middleware (~> 1.0)
+      http (>= 3.0, < 5.0)
+      jsonpath (~> 1.0)
+      recursive-open-struct (~> 1.1, >= 1.1.1)
+
 PATH
   remote: .
   specs:
     fluent-plugin-enhance-k8s-metadata (2.0.0)
       concurrent-ruby (~> 1.1)
       fluentd (>= 0.14.10, < 2)
-      kubeclient (= 4.9.1)
       lru_redux (~> 1.1.0)
+      net-http-persistent (~> 3.1)
 
 GEM
   remote: https://rubygems.org/
@@ -13,12 +25,20 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     concurrent-ruby (1.1.8)
+    connection_pool (2.2.3)
     cool.io (1.7.0)
     crack (0.4.5)
       rexml
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.13.1)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday-net_http (1.0.1)
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
+    ffi (1.14.2)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -39,37 +59,26 @@ GEM
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
       http-parser (~> 1.2.0)
-    http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    http-parser (1.2.2)
-      ffi-compiler
+    http-parser (1.2.3)
+      ffi-compiler (>= 1.0, < 2.0)
     http_parser.rb (0.6.0)
-    jsonpath (1.0.6)
+    jsonpath (1.1.0)
       multi_json
-    kubeclient (4.9.1)
-      http (>= 3.0, < 5.0)
-      jsonpath (~> 1.0)
-      recursive-open-struct (~> 1.1, >= 1.1.1)
-      rest-client (~> 2.0)
     lru_redux (1.1.0)
-    mime-types (3.3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.1104)
-    msgpack (1.3.3)
+    msgpack (1.4.2)
     multi_json (1.15.0)
-    netrc (0.11.0)
-    power_assert (2.0.0)
+    multipart-post (2.1.1)
+    net-http-persistent (3.1.0)
+      connection_pool (~> 2.2)
+    power_assert (1.2.0)
     public_suffix (4.0.6)
     rake (13.0.3)
     recursive-open-struct (1.1.3)
-    rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     rexml (3.2.4)
+    ruby2_keywords (0.0.4)
     serverengine (2.2.2)
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
@@ -78,7 +87,7 @@ GEM
       power_assert
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2020.6)
+    tzinfo-data (1.2021.1)
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
@@ -95,6 +104,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 2.0)
   fluent-plugin-enhance-k8s-metadata!
+  kubeclient!
   rake (~> 13.0)
   test-unit (~> 3.0)
   webmock (~> 3.0)

--- a/fluent-plugin-enhance-k8s-metadata/fluent-plugin-enhance-k8s-metadata.gemspec
+++ b/fluent-plugin-enhance-k8s-metadata/fluent-plugin-enhance-k8s-metadata.gemspec
@@ -17,8 +17,9 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.1'
   spec.add_runtime_dependency 'fluentd', ['>= 0.14.10', '< 2']
-  spec.add_runtime_dependency 'kubeclient', '4.9.1'
+  # spec.add_runtime_dependency 'kubeclient', '4.9.1' # Git version of Kubeclient specified in Gemfile
   spec.add_runtime_dependency 'lru_redux', '~> 1.1.0'
+  spec.add_runtime_dependency 'net-http-persistent', '~> 3.1' 
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/connector.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/connector.rb
@@ -51,6 +51,7 @@ module SumoLogic
                 read: 5
               }
             )
+            client.faraday_client.adapter(:net_http_persistent)
             client.api_valid?
           end
           client

--- a/fluent-plugin-events/Gemfile
+++ b/fluent-plugin-events/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
+gem 'kubeclient', git: 'https://github.com/abonas/kubeclient/', ref: '3267dc3fd02c49e3b19f1210ff7cb84c3b2a4478' 
+ 
 gemspec

--- a/fluent-plugin-events/Gemfile.lock
+++ b/fluent-plugin-events/Gemfile.lock
@@ -1,22 +1,42 @@
+GIT
+  remote: https://github.com/abonas/kubeclient/
+  revision: 3267dc3fd02c49e3b19f1210ff7cb84c3b2a4478
+  ref: 3267dc3fd02c49e3b19f1210ff7cb84c3b2a4478
+  specs:
+    kubeclient (4.9.1)
+      faraday (~> 1.1)
+      faraday_middleware (~> 1.0)
+      http (>= 3.0, < 5.0)
+      jsonpath (~> 1.0)
+      recursive-open-struct (~> 1.1, >= 1.1.1)
+
 PATH
   remote: .
   specs:
     fluent-plugin-events (2.0.0)
       fluentd (>= 0.14.10, < 2)
-      kubeclient (= 4.9.1)
+      net-http-persistent (~> 3.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
+    connection_pool (2.2.3)
     cool.io (1.7.0)
     crack (0.4.5)
       rexml
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.13.1)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday-net_http (1.0.1)
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
+    ffi (1.14.2)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
@@ -37,37 +57,26 @@ GEM
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
       http-parser (~> 1.2.0)
-    http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    http-parser (1.2.2)
-      ffi-compiler
+    http-parser (1.2.3)
+      ffi-compiler (>= 1.0, < 2.0)
     http_parser.rb (0.6.0)
-    jsonpath (1.0.6)
+    jsonpath (1.1.0)
       multi_json
-    kubeclient (4.9.1)
-      http (>= 3.0, < 5.0)
-      jsonpath (~> 1.0)
-      recursive-open-struct (~> 1.1, >= 1.1.1)
-      rest-client (~> 2.0)
-    mime-types (3.3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.1104)
     mocha (1.12.0)
-    msgpack (1.3.3)
+    msgpack (1.4.2)
     multi_json (1.15.0)
-    netrc (0.11.0)
-    power_assert (2.0.0)
+    multipart-post (2.1.1)
+    net-http-persistent (3.1.0)
+      connection_pool (~> 2.2)
+    power_assert (1.2.0)
     public_suffix (4.0.6)
     rake (13.0.3)
     recursive-open-struct (1.1.3)
-    rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     rexml (3.2.4)
+    ruby2_keywords (0.0.4)
     serverengine (2.2.2)
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
@@ -76,7 +85,7 @@ GEM
       power_assert
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2020.6)
+    tzinfo-data (1.2021.1)
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
@@ -93,6 +102,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 2.0)
   fluent-plugin-events!
+  kubeclient!
   mocha
   rake (~> 13.0)
   test-unit (~> 3.0)

--- a/fluent-plugin-events/fluent-plugin-events.gemspec
+++ b/fluent-plugin-events/fluent-plugin-events.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
   spec.add_runtime_dependency "fluentd", [">= 0.14.10", "< 2"]
-  spec.add_runtime_dependency 'kubeclient', '4.9.1'
+  # spec.add_runtime_dependency 'kubeclient', '4.9.1' # Git version of Kubeclient specified in Gemfile
+  spec.add_runtime_dependency 'net-http-persistent', '~> 3.1'
   spec.add_development_dependency 'webmock', '~> 3.0'
   spec.add_development_dependency 'mocha'
 end

--- a/fluent-plugin-events/lib/sumologic/kubernetes/connector.rb
+++ b/fluent-plugin-events/lib/sumologic/kubernetes/connector.rb
@@ -45,6 +45,7 @@ module SumoLogic
               ssl_options: ssl_options,
               auth_options: auth_options
             )
+            client.faraday_client.adapter(:net_http_persistent)
             client.api_valid?
           end
           client

--- a/fluent-plugin-kubernetes-metadata-filter/Gemfile
+++ b/fluent-plugin-kubernetes-metadata-filter/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+gem 'kubeclient', git: 'https://github.com/abonas/kubeclient/', ref: '3267dc3fd02c49e3b19f1210ff7cb84c3b2a4478' 
+
 gem 'codeclimate-test-reporter', '<2.0.0', :group => :test, :require => nil
 gem 'rubocop', require: false
 

--- a/fluent-plugin-kubernetes-metadata-filter/Gemfile.lock
+++ b/fluent-plugin-kubernetes-metadata-filter/Gemfile.lock
@@ -1,10 +1,22 @@
+GIT
+  remote: https://github.com/abonas/kubeclient/
+  revision: 3267dc3fd02c49e3b19f1210ff7cb84c3b2a4478
+  ref: 3267dc3fd02c49e3b19f1210ff7cb84c3b2a4478
+  specs:
+    kubeclient (4.9.1)
+      faraday (~> 1.1)
+      faraday_middleware (~> 1.0)
+      http (>= 3.0, < 5.0)
+      jsonpath (~> 1.0)
+      recursive-open-struct (~> 1.1, >= 1.1.1)
+
 PATH
   remote: .
   specs:
     fluent-plugin-kubernetes-metadata-filter (2.5.3)
       fluentd (>= 0.14.0, < 1.13)
-      kubeclient (< 5)
       lru_redux
+      net-http-persistent (~> 3.1)
 
 GEM
   remote: https://rubygems.org/
@@ -16,7 +28,8 @@ GEM
     charlock_holmes (0.7.7)
     codeclimate-test-reporter (1.0.9)
       simplecov (<= 0.13)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
+    connection_pool (2.2.3)
     cool.io (1.7.0)
     copyright-header (1.0.22)
       github-linguist
@@ -26,6 +39,13 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     escape_utils (1.2.1)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday-net_http (1.0.1)
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
     ffi (1.14.2)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
@@ -52,30 +72,23 @@ GEM
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
       http-parser (~> 1.2.0)
-    http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    http-parser (1.2.2)
-      ffi-compiler
+    http-parser (1.2.3)
+      ffi-compiler (>= 1.0, < 2.0)
     http_parser.rb (0.6.0)
     json (2.3.1)
     jsonpath (1.1.0)
       multi_json
-    kubeclient (4.9.1)
-      http (>= 3.0, < 5.0)
-      jsonpath (~> 1.0)
-      recursive-open-struct (~> 1.1, >= 1.1.1)
-      rest-client (~> 2.0)
     lru_redux (1.1.0)
-    mime-types (3.3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.1104)
     mini_mime (1.0.2)
     minitest (5.14.3)
-    msgpack (1.3.3)
+    msgpack (1.4.2)
     multi_json (1.15.0)
-    netrc (0.11.0)
+    multipart-post (2.1.1)
+    net-http-persistent (3.1.0)
+      connection_pool (~> 2.2)
     parallel (1.20.1)
     parser (3.0.0.0)
       ast (~> 2.4.1)
@@ -85,11 +98,6 @@ GEM
     rake (13.0.3)
     recursive-open-struct (1.1.3)
     regexp_parser (2.0.3)
-    rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     rexml (3.2.4)
     rr (1.2.1)
     rubocop (1.9.1)
@@ -104,6 +112,7 @@ GEM
     rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.4)
     rugged (1.1.0)
     serverengine (2.2.2)
       sigdump (~> 0.2.2)
@@ -121,7 +130,7 @@ GEM
       test-unit (>= 2.5.2)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2020.6)
+    tzinfo-data (1.2021.1)
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
@@ -143,6 +152,7 @@ DEPENDENCIES
   codeclimate-test-reporter (< 2.0.0)
   copyright-header
   fluent-plugin-kubernetes-metadata-filter!
+  kubeclient!
   minitest (~> 5.14)
   rake
   rubocop

--- a/fluent-plugin-kubernetes-metadata-filter/fluent-plugin-kubernetes-metadata-filter.gemspec
+++ b/fluent-plugin-kubernetes-metadata-filter/fluent-plugin-kubernetes-metadata-filter.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'fluentd', '>= 0.14.0', '< 1.13'
   gem.add_runtime_dependency "lru_redux"
-  gem.add_runtime_dependency "kubeclient", '< 5'
+  # gem.add_runtime_dependency 'kubeclient', '< 5' # Git version of Kubeclient specified in Gemfile
+  gem.add_runtime_dependency 'net-http-persistent', '~> 3.1'
 
   gem.add_development_dependency "bundler", "~> 2.0"
   gem.add_development_dependency "rake"

--- a/fluent-plugin-kubernetes-metadata-filter/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/fluent-plugin-kubernetes-metadata-filter/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -240,6 +240,7 @@ module Fluent::Plugin
           auth_options: auth_options,
           as: :parsed_symbolized
         )
+        @client.faraday_client.adapter(:net_http_persistent)
 
         begin
           @client.api_valid?


### PR DESCRIPTION
The Fluentd plugins we use make a good amount of HTTP connections to the Kubernetes API server for Kubernetes metadata enrichment. Until now, the HTTP connections were being closed after each HTTP request, requiring a new HTTP connection to be established on every request to API server. This was a suboptimal solution, and the root cause for SNAT port exhaustion in AKS clusters.

With this change, we are using a yet unreleased version of [Kubeclient](https://github.com/abonas/kubeclient/) library to be able to create persistent HTTP connections. The Kubeclient library (which is used by our Fluentd plugins to make requests to k8s API server) originally used [RestClient](https://github.com/rest-client/rest-client/) gem under the hood, which does not make it possible to create persistent connections. With the unreleased version of Kubeclient, the underlying HTTP library has been changed from RestClient to [Faraday](https://github.com/lostisland/faraday), which, when used with [NetHttpPersistent adapter](https://lostisland.github.io/faraday/adapters/net-http-persistent), makes connections persistent by default.

Testing in AKS showed that SNAT port usage with persistent connections is constant, no matter how many requests our plugins make to API server.