### PR TITLE
Use numeric user ID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ RUN apt-get update \
 COPY --from=builder --chown=fluent:fluent /usr/local/bundle /usr/local/bundle
 COPY ./entrypoint.sh /bin/
 
-USER fluent
+USER 999:999
 
 ARG BUILD_TAG=latest
 ENV TAG $BUILD_TAG


### PR DESCRIPTION
When one uses this image in k8s cluster with a security context having `runAsNonRoot` set to `true` the following error is can be seen:

```
Error: container has runAsNonRoot and image has non-numeric user (fluent), cannot verify user is non-root
```

This patch fixes that by using a numeric user ID.