### PR TITLE
Downgrade google-protobuf to 3.9.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,6 +63,8 @@ updates:
 
   - package-ecosystem: "bundler"
     directory: "/fluent-plugin-protobuf"
+    ignore:
+      - dependency-name: "google-protobuf"
     schedule:
       interval: "daily"
       time: "06:00"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
 RUN gem install \
         fluentd:1.12.1 \
         concurrent-ruby:1.1.8 \
-        google-protobuf:3.15.6 \
+        google-protobuf:3.9.2 \
         lru_redux:1.1.0 \
         net-http-persistent:4.0.1 \
         snappy:0.0.17 \

--- a/fluent-plugin-protobuf/Gemfile.lock
+++ b/fluent-plugin-protobuf/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     fluent-plugin-protobuf (2.0.0)
       fluentd (>= 0.14.10, < 2)
-      google-protobuf (~> 3)
+      google-protobuf (= 3.9.2)
       snappy (> 0)
 
 GEM
@@ -22,7 +22,7 @@ GEM
       tzinfo (>= 1.0, < 3.0)
       tzinfo-data (~> 1.0)
       yajl-ruby (~> 1.0)
-    google-protobuf (3.15.6)
+    google-protobuf (3.9.2)
     http_parser.rb (0.6.0)
     msgpack (1.4.2)
     power_assert (2.0.0)
@@ -50,4 +50,4 @@ DEPENDENCIES
   test-unit (~> 3.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.14

--- a/fluent-plugin-protobuf/fluent-plugin-protobuf.gemspec
+++ b/fluent-plugin-protobuf/fluent-plugin-protobuf.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
-  spec.add_runtime_dependency "google-protobuf", "~> 3"
+  spec.add_runtime_dependency "google-protobuf", "= 3.9.2"
   spec.add_runtime_dependency "snappy", "> 0"
   spec.add_runtime_dependency "fluentd", [">= 0.14.10", "< 2"]
 end


### PR DESCRIPTION
Due to higher CPU usage on Fluentd metrics pods.