### PR TITLE
fix: Only evaluate logging expressions when needed

### DIFF
--- a/fluent-plugin-protobuf/lib/fluent/plugin/parser_protobuf.rb
+++ b/fluent-plugin-protobuf/lib/fluent/plugin/parser_protobuf.rb
@@ -17,7 +17,7 @@ module Fluent
       def parse(text)
         inflated = Snappy.inflate(text)
         decoded = WriteRequest.decode(inflated)
-        log.trace "protobuf::parse - in: (#{text.bytesize}/#{inflated.bytesize}), out: #{decoded.timeseries.length}"
+        log.trace { "protobuf::parse - in: (#{text.bytesize}/#{inflated.bytesize}), out: #{decoded.timeseries.length}" }
         record = {}
         record[KEY_TIMESERIES] = decoded.timeseries
         yield Fluent::EventTime.now, record


### PR DESCRIPTION
If log level is higher than trace, trace log messages should not be evaluated.