### PR TITLE
feat: Build images for ARM

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -10,12 +10,22 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Build kubernetes-fluentd
-        run: make build
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Show Buildx platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+
       - name: Login to AWS public ECR
         run: make login
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PUBLIC_ECR_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PUBLIC_ECR_SECRET_ACCESS_KEY }}
-      - name: Push kubernetes-fluentd
-        run: make push
+
+      - name: Build and push image
+        run: make build-push-multiplatform

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -15,17 +15,29 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+
       - name: Extract tag
         id: extract_tag
         run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"
+
       - name: Print tag
         run: echo "Running release build for ${{ steps.extract_tag.outputs.tag }}"
-      - name: Build kubernetes-fluentd
-        run: make build BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Show Buildx platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+
       - name: Login to AWS public ECR
         run: make login
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_PUBLIC_ECR_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PUBLIC_ECR_SECRET_ACCESS_KEY }}
-      - name: Push kubernetes-fluentd
-        run: make push BUILD_TAG=${{ steps.extract_tag.outputs.tag }}
+
+      - name: Build and push image
+        run: make build-push-multiplatform BUILD_TAG=${{ steps.extract_tag.outputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+ARG FLUENTD_ARCH
 FROM ruby:2.6.6 AS builder
 
 # Dependencies
@@ -91,7 +92,7 @@ RUN gem install \
 RUN rm -rf /usr/local/bundle/cache/* \
  && find /usr/local/bundle/ -name "*.o" | xargs rm
 
-FROM fluent/fluentd:v1.12.2-debian-1.1
+FROM fluent/fluentd:v1.12.2-debian${FLUENTD_ARCH}-1.1
 
 USER root
 

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ login:
 	aws ecr-public get-login-password --region us-east-1 \
 	| docker login --username AWS --password-stdin $(ECR_URL)
 
+build-push-multiplatform:
+	REPO_URL=$(REPO_URL) BUILD_TAG=$(BUILD_TAG) ./ci/build-push-multiplatform.sh
+
 .PHONY: image-test
 image-test:
 	ruby test/test_docker.rb

--- a/README.md
+++ b/README.md
@@ -1,17 +1,29 @@
 # sumologic-kubernetes-fluentd ![Dev builds](https://github.com/SumoLogic/sumologic-kubernetes-fluentd/workflows/Dev%20builds/badge.svg) [![GitHub tag](https://img.shields.io/github/tag/SumoLogic/sumologic-kubernetes-fluentd.svg)](https://gitHub.com/SumoLogic/sumologic-kubernetes-fluentd/tags/)
 
-This repository contains fluentd-plugins which are bundled into a custom
-[Fluentd](https://github.com/fluent/fluentd) image which is being used by
-[sumologic-kubernetes-collection](https://github.com/SumoLogic/sumologic-kubernetes-collection).
+This repository contains Fluentd plugins which are bundled into a custom
+[Fluentd](https://github.com/fluent/fluentd) image.
+This image is then used by [sumologic-kubernetes-collection](https://github.com/SumoLogic/sumologic-kubernetes-collection).
 
-Images from this repository are pushed to Sumo Logic public AWS ECR at `public.ecr.aws/sumologic/kubernetes-fluentd`.
+Images from this repository are pushed to Sumo Logic public AWS ECR at [public.ecr.aws/sumologic/kubernetes-fluentd](https://gallery.ecr.aws/sumologic/kubernetes-fluentd).
 
-Please take a look at `push` target in [Makefile](./Makefile) for more details.
+The images are built for the following architectures:
+
+- `linux/amd64`
+- `linux/arm/v7`
+- `linux/arm64/v8`
 
 ## Build
 
+To build image only for the build host's architecture:
+
 ```shell
 make build
+```
+
+To build image for all supported architectures and push it to a registry:
+
+```shell
+make build-push-multiplatform REPO_URL=my-repo/fluentd BUILD_TAG=custom-tag
 ```
 
 ## Test

--- a/ci/build-push-multiplatform.sh
+++ b/ci/build-push-multiplatform.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+if ! docker buildx ls | grep arm
+then
+    echo "Your Buildx seems to lack ARM architecture support"
+    exit 1
+fi
+
+docker buildx build \
+    --push \
+    --platform=linux/amd64 \
+    --build-arg FLUENTD_ARCH="" \
+    --build-arg BUILD_TAG="${BUILD_TAG}" \
+    --tag "${REPO_URL}:${BUILD_TAG}-amd64" \
+    . &
+readonly amd64_pid=$!
+
+docker buildx build \
+    --push \
+    --platform=linux/arm/v7 \
+    --build-arg FLUENTD_ARCH="-armhf" \
+    --build-arg BUILD_TAG="${BUILD_TAG}" \
+    --tag "${REPO_URL}:${BUILD_TAG}-arm" \
+    . &
+readonly arm_pid=$!
+
+docker buildx build \
+    --push \
+    --platform=linux/arm64/v8 \
+    --build-arg FLUENTD_ARCH="-arm64" \
+    --build-arg BUILD_TAG="${BUILD_TAG}" \
+    --tag "${REPO_URL}:${BUILD_TAG}-arm64" \
+    . &
+readonly arm64_pid=$!
+
+wait $amd64_pid
+wait $arm_pid
+wait $arm64_pid
+
+docker manifest create --amend \
+    "${REPO_URL}:${BUILD_TAG}" \
+    "${REPO_URL}:${BUILD_TAG}-amd64" \
+    "${REPO_URL}:${BUILD_TAG}-arm" \
+    "${REPO_URL}:${BUILD_TAG}-arm64"
+
+docker manifest push "${REPO_URL}:${BUILD_TAG}"


### PR DESCRIPTION
I wanted to achieve the following goals with this PR:
- Build Fluentd images for all platforms (amd64, arm, arm64) and push them to container registry under a common tag,
- Use single Dockerfile for all platforms, preventing duplication,
- Make it possible (and easy) to build the multi-platform image locally and push it to a custom registry.