### PR TITLE
ci: Push images to ECR in opensource account

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -29,3 +29,12 @@ jobs:
 
       - name: Build and push image
         run: make build-push-multiplatform
+
+      - name: Login to Open Source ECR
+        run: make login-opensource
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.OPENSOURCE_ECR_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.OPENSOURCE_ECR_SECRET_ACCESS_KEY }}
+
+      - name: Build and push image to Open Source ECR
+        run: make build-push-multiplatform-opensource

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ BUILD_CACHE_TAG = latest-builder-cache
 IMAGE_NAME = kubernetes-fluentd
 ECR_URL = public.ecr.aws/sumologic
 REPO_URL = $(ECR_URL)/$(IMAGE_NAME)
+OPENSOURCE_ECR_URL = public.ecr.aws/a4t4y2n3
+OPENSOURCE_REPO_URL = $(OPENSOURCE_ECR_URL)/$(IMAGE_NAME)
 
 build:
 	DOCKER_BUILDKIT=1 docker build \
@@ -32,6 +34,13 @@ login:
 
 build-push-multiplatform:
 	REPO_URL=$(REPO_URL) BUILD_TAG=$(BUILD_TAG) ./ci/build-push-multiplatform.sh
+
+login-opensource:
+	aws ecr-public get-login-password --region us-east-1 \
+	| docker login --username AWS --password-stdin $(OPENSOURCE_ECR_URL)
+
+build-push-multiplatform-opensource:
+	REPO_URL=$(OPENSOURCE_REPO_URL) BUILD_TAG=$(BUILD_TAG) ./ci/build-push-multiplatform.sh
 
 .PHONY: image-test
 image-test:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BUILD_TAG ?= latest
 BUILD_CACHE_TAG = latest-builder-cache
 IMAGE_NAME = kubernetes-fluentd
-ECR_URL = public.ecr.aws/sumologic
+ECR_URL = public.ecr.aws/u5z5f8z6
 REPO_URL = $(ECR_URL)/$(IMAGE_NAME)
 OPENSOURCE_ECR_URL = public.ecr.aws/a4t4y2n3
 OPENSOURCE_REPO_URL = $(OPENSOURCE_ECR_URL)/$(IMAGE_NAME)


### PR DESCRIPTION
A separate AWS account has been created for Sumo Logic's opensource artifacts.
During the transition period, we want to push images to both registries - the original and the opensource one.