### PR TITLE
ci(dependabot): Simplify update schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "06:00"
-      timezone: "Europe/Warsaw"
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -16,50 +14,36 @@ updates:
           - "3.x"
     schedule:
       interval: "daily"
-      time: "06:00"
-      timezone: "Europe/Warsaw"
 
   - package-ecosystem: "bundler"
     directory: "/fluent-plugin-datapoint"
     schedule:
       interval: "daily"
-      time: "06:00"
-      timezone: "Europe/Warsaw"
 
   - package-ecosystem: "bundler"
     directory: "/fluent-plugin-enhance-k8s-metadata"
     schedule:
       interval: "daily"
-      time: "06:00"
-      timezone: "Europe/Warsaw"
 
   - package-ecosystem: "bundler"
     directory: "/fluent-plugin-events"
     schedule:
       interval: "daily"
-      time: "06:00"
-      timezone: "Europe/Warsaw"
 
   - package-ecosystem: "bundler"
     directory: "/fluent-plugin-kubernetes-metadata-filter"
     schedule:
       interval: "daily"
-      time: "06:00"
-      timezone: "Europe/Warsaw"
 
   - package-ecosystem: "bundler"
     directory: "/fluent-plugin-kubernetes-sumologic"
     schedule:
       interval: "daily"
-      time: "06:00"
-      timezone: "Europe/Warsaw"
 
   - package-ecosystem: "bundler"
     directory: "/fluent-plugin-prometheus-format"
     schedule:
       interval: "daily"
-      time: "06:00"
-      timezone: "Europe/Warsaw"
 
   - package-ecosystem: "bundler"
     directory: "/fluent-plugin-protobuf"
@@ -67,5 +51,3 @@ updates:
       - dependency-name: "google-protobuf"
     schedule:
       interval: "daily"
-      time: "06:00"
-      timezone: "Europe/Warsaw"


### PR DESCRIPTION
Due to a recent change in how Dependabot schedules updates, the `time` and `timezone` entries are no longer needed.
See https://github.blog/changelog/2021-06-16-dependabot-now-schedules-version-updates-uniformly/.