### PR TITLE
fix: Use Buster-based Ruby for builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG FLUENTD_ARCH
-FROM ruby:2.6.8 AS builder
+FROM ruby:2.6.8-buster AS builder
 
 # Dependencies
 RUN apt-get update \


### PR DESCRIPTION
The `ruby:2.6.8` image tag was changed some hours ago by the Ruby team to be based on Debian 11 `bullseye` instead of Debian 9 `stretch`. This caused native dependency errors from `ffi` gem.

This change updates the base image for the builder image to `ruby:2.6.8-buster` to avoid the ffi error. It also matches the Fluentd image, which is also based on `buster`.