### PR TITLE
fix(alpine): Add missing gems

### DIFF
--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -13,11 +13,16 @@ RUN echo 'gem: --no-document' >> /etc/gemrc
 
 # Fluentd plugin dependencies
 RUN gem install \
-        fluentd:1.12.2 \
+        async-http:0.54.0 \
+        bigdecimal:1.4.4 \
         concurrent-ruby:1.1.8 \
+        ext_monitor:0.1.2 \
+        fluentd:1.12.2 \
         google-protobuf:3.17.3 \
+        json:2.4.1 \
         lru_redux:1.1.0 \
         net-http-persistent:4.0.1 \
+        oj:3.10.18 \
         snappy:0.0.17 \
         specific_install:0.3.5
 


### PR DESCRIPTION
Adds gems that exist in the upstream Fluentd image
at https://github.com/fluent/fluentd-docker-image/blob/209628f474f60bc6ff05c8c1ab8ca06dd538c44d/v1.12/alpine/Dockerfile#L22-L28.
Not including resolv:0.2.1, because I believe
it's already bundled with Ruby 2.6.8.