### PR TITLE
fix(prometheus_format): ignore fields with null value

### DIFF
--- a/fluent-plugin-prometheus-format/README.md
+++ b/fluent-plugin-prometheus-format/README.md
@@ -2,8 +2,13 @@
 
 [Fluentd](https://fluentd.org/) filter plugin to transform data points to prometheus format.
 
-- All fields of the metric will be serialized as intrinsic tags (dimensions) in the prometheus format.
-- Sample of Input
+All fields of the metric will be serialized as intrinsic tags (dimensions) in the prometheus format.
+
+Fields with empty string as value as passed without change. Fields with `null` as value are dropped.
+
+## Example
+
+Given the following Fluentd event as input:
 
 ```json
 {
@@ -29,7 +34,7 @@
 }
 ```
 
-- Sample of Output
+the following Fluentd event goes out:
 
 ```json
 {

--- a/fluent-plugin-prometheus-format/lib/fluent/plugin/filter_prometheus_format.rb
+++ b/fluent-plugin-prometheus-format/lib/fluent/plugin/filter_prometheus_format.rb
@@ -119,7 +119,7 @@ module Fluent
         array = @sort_labels ? hash.sort : hash.to_a
         array.map do |key, value|
           "#{key}=\"#{escape(value)}\""\
-            unless [KEY_METRIC, KEY_TIMESTAMP, KEY_VALUE].include?(key)
+            unless value.nil? || [KEY_METRIC, KEY_TIMESTAMP, KEY_VALUE].include?(key)
         end.compact.join(',')
       end
 

--- a/fluent-plugin-prometheus-format/test/plugin/test_filter_prometheus_format.rb
+++ b/fluent-plugin-prometheus-format/test/plugin/test_filter_prometheus_format.rb
@@ -14,6 +14,13 @@ class PrometheusFormatFilterTest < Test::Unit::TestCase
       verify_with_expected outputs, 'output.datapoint'
     end
 
+    test 'transform empty keys' do
+      config = %([])
+      outputs = filter_datapoints(config, 'datapoint.empty')
+      assert_equal 1, outputs.length
+      verify_with_expected outputs, 'output.datapoint.empty'
+    end
+
     test 'relabel keys' do
       config = %([
         relabel {

--- a/fluent-plugin-prometheus-format/test/resources/datapoint.empty.json
+++ b/fluent-plugin-prometheus-format/test/resources/datapoint.empty.json
@@ -1,0 +1,11 @@
+{
+	"datapoints": [
+	    {
+		"emptykey1": "",
+		"nullkey2": null,
+		"@metric": "some_metric",
+		"@timestamp": 1550862304339,
+		"@value": 1619905.0
+	    }
+	]
+    }

--- a/fluent-plugin-prometheus-format/test/resources/output.datapoint.empty.json
+++ b/fluent-plugin-prometheus-format/test/resources/output.datapoint.empty.json
@@ -1,0 +1,7 @@
+{
+    "outputs": [
+        {
+            "message": "some_metric{emptykey1=\"\",_origin=\"kubernetes\"} 1619905.0 1550862304339"
+        }
+    ]
+}


### PR DESCRIPTION
Before this change, this plugin would fail on an event with a field that has value `null`.
The reason was that the `escape` method assumes the value is not null.