### PR TITLE
Revert "feat(enhance_k8s_metadata): add `watch` option"

### DIFF
--- a/fluent-plugin-enhance-k8s-metadata/README.md
+++ b/fluent-plugin-enhance-k8s-metadata/README.md
@@ -39,5 +39,3 @@ bundle
 ## Configuration
 
 TBD
-
-- `watch` - set up a watch on endpoints on the Kubernetes API server for updates to pod metadata (default: `true`)

--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -24,7 +24,6 @@ module Fluent
 
       # parameters for connecting to k8s api server
       config_param :kubernetes_url, :string, default: nil
-      config_param :watch, :bool, default: true
       config_param :client_cert, :string, default: nil
       config_param :client_key, :string, default: nil
       config_param :ca_file, :string, default: nil
@@ -59,7 +58,7 @@ module Fluent
 
       def start
         super
-        start_service_monitor(@watch)
+        start_service_monitor
       end
 
       def filter(tag, time, record)

--- a/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/service_monitor.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/service_monitor.rb
@@ -6,12 +6,7 @@ module SumoLogic
     module ServiceMonitor
       require_relative 'connector.rb'
 
-      def start_service_monitor(is_watch_enabled)
-        if !is_watch_enabled
-          log.info "Watch is disabled - not watching for service changes."
-          return
-        end
-
+      def start_service_monitor
         log.info "Starting watching for service changes"
         @watch_service_interval_seconds = 300
         thread_create(:"watch_endpoints") {


### PR DESCRIPTION
This reverts commit 0abdce18db3c60f198f38a5da0196f7ff6147c5b.

Disabling watching in the `enhance_k8s_metadata` plugin causes the `service` label to be missing.