### PR TITLE
feat: expose `keepalive` option to disable persistent connections to API server

### DIFF
--- a/fluent-plugin-enhance-k8s-metadata/README.md
+++ b/fluent-plugin-enhance-k8s-metadata/README.md
@@ -39,3 +39,5 @@ bundle
 ## Configuration
 
 TBD
+
+- `keepalive` - defines whether HTTP connections to Kubernetes API server should be persistent (default: `true`)

--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -24,6 +24,7 @@ module Fluent
 
       # parameters for connecting to k8s api server
       config_param :kubernetes_url, :string, default: nil
+      config_param :keepalive, :bool, default: true
       config_param :client_cert, :string, default: nil
       config_param :client_key, :string, default: nil
       config_param :ca_file, :string, default: nil

--- a/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/connector.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/sumologic/kubernetes/connector.rb
@@ -51,7 +51,9 @@ module SumoLogic
                 read: 5
               }
             )
-            client.faraday_client.adapter(:net_http_persistent)
+            if @keepalive
+              client.faraday_client.adapter(:net_http_persistent)
+            end
             client.api_valid?
           end
           client

--- a/fluent-plugin-events/README.md
+++ b/fluent-plugin-events/README.md
@@ -30,6 +30,7 @@ configmap_update_interval_seconds | 10 | Resource version is used to resume even
 watch_interval_seconds | 300 | Interval at which the watch thread gets recreated.
 deploy_namespace | "sumologic" | Namespace that the events plugin resources will be created in. 
 kubernetes_url | nil | URL of the Kubernetes API.
+keepalive | true | Defines whether HTTP connections to Kubernetes API server should be persistent
 client_cert | nil | Path to the certificate file for the client.
 client_key | nil | Path to the private key file for the client.
 ca_file | nil | Path to the CA file.

--- a/fluent-plugin-events/lib/fluent/plugin/in_events.rb
+++ b/fluent-plugin-events/lib/fluent/plugin/in_events.rb
@@ -14,6 +14,7 @@ module Fluent
       
       # parameters for connecting to k8s api server
       config_param :kubernetes_url, :string, default: nil
+      config_param :keepalive, :bool, default: true
       # api_version is used to create:
       # * a group api e.g. "events.k8s.io/v1beta1" additionally to 'v1' api
       # * a regular api e.g. 'v1', if a different version than 'v1' is specified

--- a/fluent-plugin-events/lib/sumologic/kubernetes/connector.rb
+++ b/fluent-plugin-events/lib/sumologic/kubernetes/connector.rb
@@ -45,7 +45,9 @@ module SumoLogic
               ssl_options: ssl_options,
               auth_options: auth_options
             )
-            client.faraday_client.adapter(:net_http_persistent)
+            if @keepalive
+              client.faraday_client.adapter(:net_http_persistent)
+            end
             client.api_valid?
           end
           client

--- a/fluent-plugin-kubernetes-metadata-filter/README.md
+++ b/fluent-plugin-kubernetes-metadata-filter/README.md
@@ -42,6 +42,7 @@ This must used named capture groups for `container_name`, `pod_name` & `namespac
 * `cache_size` - size of the cache of Kubernetes metadata to reduce requests to the API server (default: `1000`)
 * `cache_ttl` - TTL in seconds of each cached element. Set to negative value to disable TTL eviction (default: `3600` - 1 hour)
 * `watch` - set up a watch on pods on the API server for updates to metadata (default: `true`)
+* `keepalive` - defines whether HTTP connections to Kubernetes API server should be persistent (default: `true`)
 * `de_dot` - replace dots in labels and annotations with configured `de_dot_separator`, required for ElasticSearch 2.x compatibility (default: `true`)
 * `de_dot_separator` - separator to use if `de_dot` is enabled (default: `_`)
 * *DEPRECATED* `use_journal` - If false, messages are expected to be formatted and tagged as if read by the fluentd in\_tail plugin with wildcard filename.  If true, messages are expected to be formatted as if read from the systemd journal.  The `MESSAGE` field has the full message.  The `CONTAINER_NAME` field has the encoded k8s metadata (see below).  The `CONTAINER_ID_FULL` field has the full container uuid.  This requires docker to use the `--log-driver=journald` log driver.  If unset (the default), the plugin will use the `CONTAINER_NAME` and `CONTAINER_ID_FULL` fields

--- a/fluent-plugin-kubernetes-metadata-filter/lib/fluent/plugin/filter_kubernetes_metadata.rb
+++ b/fluent-plugin-kubernetes-metadata-filter/lib/fluent/plugin/filter_kubernetes_metadata.rb
@@ -42,6 +42,7 @@ module Fluent::Plugin
     config_param :cache_size, :integer, default: 1000
     config_param :cache_ttl, :integer, default: 60 * 60
     config_param :watch, :bool, default: true
+    config_param :keepalive, :bool, default: true
     config_param :apiVersion, :string, default: 'v1'
     config_param :client_cert, :string, default: nil
     config_param :client_key, :string, default: nil
@@ -240,7 +241,9 @@ module Fluent::Plugin
           auth_options: auth_options,
           as: :parsed_symbolized
         )
-        @client.faraday_client.adapter(:net_http_persistent)
+        if @keepalive
+          @client.faraday_client.adapter(:net_http_persistent)
+        end
 
         begin
           @client.api_valid?


### PR DESCRIPTION
Three plugins make connections to the Kubernetes API server:
- enhance_k8s_metadata
- events
- kubernetes_metadata

All of those by default make persistent connections to the Kubernetes API server.
This change exposes a new `keepalive` option that allows to change it.