### PR TITLE
ci(dependabot): change ignore config for Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,9 @@ updates:
     directory: "/"
     ignore:
       - dependency-name: "ruby"
-        versions:
-          - "2.7.x"
-          - "3.x"
+        update-types:
+          - "version-update:semver:major"
+          - "version-update:semver:minor"
     schedule:
       interval: "daily"
 


### PR DESCRIPTION
Apparently the existing ignore config does not work,
because Dependabot created a 2.7.x update for Ruby: #367.
Let's see if a taking different approach helps.