### PR TITLE
ci: fix Dependabot config for Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,8 @@ updates:
     ignore:
       - dependency-name: "ruby"
         update-types:
-          - "version-update:semver:major"
-          - "version-update:semver:minor"
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
     schedule:
       interval: "daily"
 


### PR DESCRIPTION
Apparently there was a typo in the config which went unnoticed until now.

https://github.com/SumoLogic/sumologic-kubernetes-fluentd/runs/4978597076

```
Dependabot encountered the following error when parsing your .github/dependabot.yml:

The property '#/updates/1/ignore/0/update-types/0' value "version-update:semver:major" did not match one of the following values: version-update:semver-major, version-update:semver-minor, version-update:semver-patch
The property '#/updates/1/ignore/0/update-types/1' value "version-update:semver:minor" did not match one of the following values: version-update:semver-major, version-update:semver-minor, version-update:semver-patch

Please update the config file to conform with Dependabot's specification.
```