### PR TITLE
chore: bump the Sumo output plugin to 1.7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN gem install \
         fluent-plugin-prometheus:1.6.1 \
         fluent-plugin-record-modifier:2.0.1 \
         fluent-plugin-rewrite-tag-filter:2.2.0 \
-        fluent-plugin-sumologic_output:1.7.3 \
+        fluent-plugin-sumologic_output:1.7.4 \
         fluent-plugin-systemd:1.0.2
 
 WORKDIR /sumologic-kubernetes-fluentd

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -49,7 +49,7 @@ RUN gem install \
         fluent-plugin-prometheus:1.6.1 \
         fluent-plugin-record-modifier:2.0.1 \
         fluent-plugin-rewrite-tag-filter:2.2.0 \
-        fluent-plugin-sumologic_output:1.7.3 \
+        fluent-plugin-sumologic_output:1.7.4 \
         fluent-plugin-systemd:1.0.2
 
 WORKDIR /sumologic-kubernetes-fluentd


### PR DESCRIPTION
See: https://github.com/SumoLogic/fluentd-output-sumologic/releases/tag/1.7.4. The only change is logging receiver warnings.