### PR TITLE
 chore: bump Fluentd to v1.14.6 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN gem install \
 
 # Fluentd plugin dependencies
 RUN gem install \
-        fluentd:1.14.5 \
+        fluentd:1.14.6 \
         concurrent-ruby:1.1.8 \
         google-protobuf:3.19.2 \
         lru_redux:1.1.0 \
@@ -99,7 +99,7 @@ RUN gem install \
 RUN rm -rf /usr/local/bundle/cache/* \
  && find /usr/local/bundle/ -name "*.o" | xargs rm
 
-FROM fluent/fluentd:v1.14.5-debian${FLUENTD_ARCH}-1.0
+FROM fluent/fluentd:v1.14.6-debian${FLUENTD_ARCH}-1.0
 
 USER root
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,9 @@ Vagrant.configure('2') do |config|
   config.disksize.size = '50GB'
   config.vm.box_check_update = false
   config.vm.host_name = 'sumologic-kubernetes-fluentd'
-  config.vm.network :private_network, ip: "192.168.78.44"
+  # Vbox 6.1.28+ restricts host-only adapters to 192.168.56.0/21
+  # See: https://www.virtualbox.org/manual/ch06.html#network_hostonly
+  config.vm.network :private_network, ip: "192.168.56.44"
 
   config.vm.provider 'virtualbox' do |vb|
     vb.gui = false

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -24,7 +24,7 @@ RUN gem install \
         bigdecimal:1.4.4 \
         concurrent-ruby:1.1.8 \
         ext_monitor:0.1.2 \
-        fluentd:1.14.5 \
+        fluentd:1.14.6 \
         google-protobuf:3.19.2 \
         json:2.4.1 \
         lru_redux:1.1.0 \

--- a/fluent-plugin-datapoint/Gemfile.lock
+++ b/fluent-plugin-datapoint/Gemfile.lock
@@ -2,14 +2,14 @@ PATH
   remote: .
   specs:
     fluent-plugin-datapoint (2.0.0)
-      fluentd (= 1.14.5)
+      fluentd (= 1.14.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     cool.io (1.7.1)
-    fluentd (1.14.5)
+    fluentd (1.14.6)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.9.0)
@@ -22,7 +22,7 @@ GEM
       webrick (>= 1.4.2, < 1.8.0)
       yajl-ruby (~> 1.0)
     http_parser.rb (0.8.0)
-    msgpack (1.4.5)
+    msgpack (1.5.1)
     power_assert (2.0.1)
     rake (13.0.6)
     serverengine (2.2.5)
@@ -33,7 +33,7 @@ GEM
       power_assert
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2021.5)
+    tzinfo-data (1.2022.1)
       tzinfo (>= 1.0.0)
     webrick (1.7.0)
     yajl-ruby (1.4.2)

--- a/fluent-plugin-datapoint/fluent-plugin-datapoint.gemspec
+++ b/fluent-plugin-datapoint/fluent-plugin-datapoint.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
-  spec.add_runtime_dependency "fluentd", "= 1.14.5"
+  spec.add_runtime_dependency "fluentd", "= 1.14.6"
 end

--- a/fluent-plugin-enhance-k8s-metadata/Gemfile.lock
+++ b/fluent-plugin-enhance-k8s-metadata/Gemfile.lock
@@ -15,7 +15,7 @@ PATH
   specs:
     fluent-plugin-enhance-k8s-metadata (2.0.0)
       concurrent-ruby (~> 1.1)
-      fluentd (= 1.14.5)
+      fluentd (= 1.14.6)
       lru_redux (~> 1.1.0)
       net-http-persistent (~> 4.0)
 
@@ -25,7 +25,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     concurrent-ruby (1.1.10)
-    connection_pool (2.2.3)
+    connection_pool (2.2.5)
     cool.io (1.7.1)
     crack (0.4.5)
       rexml
@@ -42,7 +42,7 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    fluentd (1.14.5)
+    fluentd (1.14.6)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.9.0)
@@ -69,7 +69,7 @@ GEM
     jsonpath (1.1.0)
       multi_json
     lru_redux (1.1.0)
-    msgpack (1.4.5)
+    msgpack (1.5.1)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     net-http-persistent (4.0.1)
@@ -88,7 +88,7 @@ GEM
       power_assert
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2021.5)
+    tzinfo-data (1.2022.1)
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext

--- a/fluent-plugin-enhance-k8s-metadata/fluent-plugin-enhance-k8s-metadata.gemspec
+++ b/fluent-plugin-enhance-k8s-metadata/fluent-plugin-enhance-k8s-metadata.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.1'
-  spec.add_runtime_dependency "fluentd", "= 1.14.5"
+  spec.add_runtime_dependency "fluentd", "= 1.14.6"
   # spec.add_runtime_dependency 'kubeclient', '4.9.1' # Git version of Kubeclient specified in Gemfile
   spec.add_runtime_dependency 'lru_redux', '~> 1.1.0'
   spec.add_runtime_dependency 'net-http-persistent', '~> 4.0'

--- a/fluent-plugin-events/Gemfile.lock
+++ b/fluent-plugin-events/Gemfile.lock
@@ -14,7 +14,7 @@ PATH
   remote: .
   specs:
     fluent-plugin-events (2.0.0)
-      fluentd (= 1.14.5)
+      fluentd (= 1.14.6)
       net-http-persistent (~> 4.0)
 
 GEM
@@ -22,8 +22,8 @@ GEM
   specs:
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    concurrent-ruby (1.1.9)
-    connection_pool (2.2.3)
+    concurrent-ruby (1.1.10)
+    connection_pool (2.2.5)
     cool.io (1.7.1)
     crack (0.4.5)
       rexml
@@ -40,7 +40,7 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    fluentd (1.14.5)
+    fluentd (1.14.6)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.9.0)
@@ -67,7 +67,7 @@ GEM
     jsonpath (1.1.0)
       multi_json
     mocha (1.13.0)
-    msgpack (1.4.5)
+    msgpack (1.5.1)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     net-http-persistent (4.0.1)
@@ -86,7 +86,7 @@ GEM
       power_assert
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2021.5)
+    tzinfo-data (1.2022.1)
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext

--- a/fluent-plugin-events/fluent-plugin-events.gemspec
+++ b/fluent-plugin-events/fluent-plugin-events.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
-  spec.add_runtime_dependency "fluentd", "= 1.14.5"
+  spec.add_runtime_dependency "fluentd", "= 1.14.6"
   # spec.add_runtime_dependency 'kubeclient', '4.9.1' # Git version of Kubeclient specified in Gemfile
   spec.add_runtime_dependency 'net-http-persistent', '~> 4.0'
   spec.add_development_dependency 'webmock', '~> 3.0'

--- a/fluent-plugin-kubernetes-metadata-filter/Gemfile.lock
+++ b/fluent-plugin-kubernetes-metadata-filter/Gemfile.lock
@@ -14,7 +14,7 @@ PATH
   remote: .
   specs:
     fluent-plugin-kubernetes-metadata-filter (2.5.3)
-      fluentd (= 1.14.5)
+      fluentd (= 1.14.6)
       lru_redux
       net-http-persistent (~> 4.0)
 
@@ -28,8 +28,8 @@ GEM
     charlock_holmes (0.7.7)
     codeclimate-test-reporter (1.0.9)
       simplecov (<= 0.13)
-    concurrent-ruby (1.1.9)
-    connection_pool (2.2.3)
+    concurrent-ruby (1.1.10)
+    connection_pool (2.2.5)
     cool.io (1.7.1)
     copyright-header (1.0.22)
       github-linguist
@@ -50,7 +50,7 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    fluentd (1.14.5)
+    fluentd (1.14.6)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.9.0)
@@ -85,7 +85,7 @@ GEM
     lru_redux (1.1.0)
     mini_mime (1.0.2)
     minitest (5.15.0)
-    msgpack (1.4.5)
+    msgpack (1.5.1)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     net-http-persistent (4.0.1)
@@ -131,7 +131,7 @@ GEM
       test-unit (>= 2.5.2)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2021.5)
+    tzinfo-data (1.2022.1)
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext

--- a/fluent-plugin-kubernetes-metadata-filter/fluent-plugin-kubernetes-metadata-filter.gemspec
+++ b/fluent-plugin-kubernetes-metadata-filter/fluent-plugin-kubernetes-metadata-filter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.5.0'
 
-  gem.add_runtime_dependency "fluentd", "= 1.14.5"
+  gem.add_runtime_dependency "fluentd", "= 1.14.6"
   gem.add_runtime_dependency "lru_redux"
   # gem.add_runtime_dependency 'kubeclient', '< 5' # Git version of Kubeclient specified in Gemfile
   gem.add_runtime_dependency 'net-http-persistent', '~> 4.0'

--- a/fluent-plugin-kubernetes-sumologic/Gemfile.lock
+++ b/fluent-plugin-kubernetes-sumologic/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     fluent-plugin-kubernetes-sumologic (2.0.0)
-      fluentd (= 1.14.5)
+      fluentd (= 1.14.6)
       httpclient (~> 2.8.0)
 
 GEM
@@ -12,12 +12,12 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     codecov (0.6.0)
       simplecov (>= 0.15, < 0.22)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     cool.io (1.7.1)
     crack (0.4.5)
       rexml
     docile (1.4.0)
-    fluentd (1.14.5)
+    fluentd (1.14.6)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.9.0)
@@ -32,7 +32,7 @@ GEM
     hashdiff (1.0.1)
     http_parser.rb (0.8.0)
     httpclient (2.8.3)
-    msgpack (1.4.5)
+    msgpack (1.5.1)
     power_assert (2.0.1)
     public_suffix (4.0.6)
     rake (13.0.6)
@@ -51,7 +51,7 @@ GEM
       power_assert
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2021.5)
+    tzinfo-data (1.2022.1)
       tzinfo (>= 1.0.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)

--- a/fluent-plugin-kubernetes-sumologic/fluent-plugin-kubernetes-sumologic.gemspec
+++ b/fluent-plugin-kubernetes-sumologic/fluent-plugin-kubernetes-sumologic.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'test-unit', '~> 3.5.3'
   spec.add_development_dependency "codecov", ">= 0.1.10"
-  spec.add_runtime_dependency "fluentd", "= 1.14.5"
+  spec.add_runtime_dependency "fluentd", "= 1.14.6"
   spec.add_runtime_dependency 'httpclient', '~> 2.8.0'
 end

--- a/fluent-plugin-prometheus-format/Gemfile.lock
+++ b/fluent-plugin-prometheus-format/Gemfile.lock
@@ -2,14 +2,14 @@ PATH
   remote: .
   specs:
     fluent-plugin-prometheus-format (2.0.0)
-      fluentd (= 1.14.5)
+      fluentd (= 1.14.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     cool.io (1.7.1)
-    fluentd (1.14.5)
+    fluentd (1.14.6)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.9.0)
@@ -22,7 +22,7 @@ GEM
       webrick (>= 1.4.2, < 1.8.0)
       yajl-ruby (~> 1.0)
     http_parser.rb (0.8.0)
-    msgpack (1.4.5)
+    msgpack (1.5.1)
     power_assert (2.0.1)
     rake (13.0.6)
     serverengine (2.2.5)
@@ -33,7 +33,7 @@ GEM
       power_assert
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2021.5)
+    tzinfo-data (1.2022.1)
       tzinfo (>= 1.0.0)
     webrick (1.7.0)
     yajl-ruby (1.4.2)

--- a/fluent-plugin-prometheus-format/fluent-plugin-prometheus-format.gemspec
+++ b/fluent-plugin-prometheus-format/fluent-plugin-prometheus-format.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
-  spec.add_runtime_dependency "fluentd", "= 1.14.5"
+  spec.add_runtime_dependency "fluentd", "= 1.14.6"
 end

--- a/fluent-plugin-protobuf/Gemfile.lock
+++ b/fluent-plugin-protobuf/Gemfile.lock
@@ -2,16 +2,16 @@ PATH
   remote: .
   specs:
     fluent-plugin-protobuf (2.0.0)
-      fluentd (= 1.14.5)
+      fluentd (= 1.14.6)
       google-protobuf (~> 3.17)
       snappy (> 0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     cool.io (1.7.1)
-    fluentd (1.14.5)
+    fluentd (1.14.6)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.9.0)
@@ -25,7 +25,7 @@ GEM
       yajl-ruby (~> 1.0)
     google-protobuf (3.20.0)
     http_parser.rb (0.8.0)
-    msgpack (1.4.5)
+    msgpack (1.5.1)
     power_assert (2.0.1)
     rake (13.0.6)
     serverengine (2.2.5)
@@ -37,7 +37,7 @@ GEM
       power_assert
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2021.5)
+    tzinfo-data (1.2022.1)
       tzinfo (>= 1.0.0)
     webrick (1.7.0)
     yajl-ruby (1.4.2)

--- a/fluent-plugin-protobuf/fluent-plugin-protobuf.gemspec
+++ b/fluent-plugin-protobuf/fluent-plugin-protobuf.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit", "~> 3.0"
   spec.add_runtime_dependency "google-protobuf", "~> 3.17"
   spec.add_runtime_dependency "snappy", "> 0"
-  spec.add_runtime_dependency "fluentd", "= 1.14.5"
+  spec.add_runtime_dependency "fluentd", "= 1.14.6"
 end


### PR DESCRIPTION
- chore: change Vagrant IP address for vbox 6.1.28 compat
- chore: bump Fluentd to v1.14.6
