### PR TITLE
Handle IPv6 KUBERNETES_SERVICE_HOST

### DIFF
--- a/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
+++ b/fluent-plugin-enhance-k8s-metadata/lib/fluent/plugin/filter_enhance_k8s_metadata.rb
@@ -128,7 +128,15 @@ module Fluent
           log.info 'Kubernetes URL is not set - inspecting environment'
           env_host = ENV['KUBERNETES_SERVICE_HOST']
           env_port = ENV['KUBERNETES_SERVICE_PORT']
-          @kubernetes_url = "https://#{env_host}:#{env_port}" unless env_host.nil? || env_port.nil?
+          if present?(env_host) && present?(env_port)
+            if env_host =~ Resolv::IPv6::Regex
+              # Brackets are needed around IPv6 addresses
+              env_host = "[#{env_host}]"
+            end
+            @kubernetes_url = "https://#{env_host}:#{env_port}"
+          else
+            log.debug "No Kubernetes URL could be found in config or environment"
+          end
         end
         log.debug "Kubernetes URL: '#{@kubernetes_url}'"
 

--- a/fluent-plugin-events/lib/fluent/plugin/in_events.rb
+++ b/fluent-plugin-events/lib/fluent/plugin/in_events.rb
@@ -191,7 +191,15 @@ module Fluent
           log.debug 'Kubernetes URL is not set - inspecting environment'
           env_host = ENV['KUBERNETES_SERVICE_HOST']
           env_port = ENV['KUBERNETES_SERVICE_PORT']
-          @kubernetes_url = "https://#{env_host}:#{env_port}" unless env_host.nil? || env_port.nil?
+          if present?(env_host) && present?(env_port)
+            if env_host =~ Resolv::IPv6::Regex
+              # Brackets are needed around IPv6 addresses
+              env_host = "[#{env_host}]"
+            end
+            @kubernetes_url = "https://#{env_host}:#{env_port}"
+          else
+            log.debug "No Kubernetes URL could be found in config or environment"
+          end
         end
         log.debug "Kubernetes URL: '#{@kubernetes_url}'"
 


### PR DESCRIPTION
Fixes two cases where `KUBERNETES_SERVICE_HOST` is used without proper handling for it potentially being an IPv6 address. The changes are derived from the third case in [fluent-plugin-kubernetes-metadata-filter/lib/fluent/plugin/filter_kubernetes_metadata.rb](https://github.com/SumoLogic/sumologic-kubernetes-fluentd/blame/dfb5d5d6b24b1e4ff7dd8ac094e3ad8c7d482720/fluent-plugin-kubernetes-metadata-filter/lib/fluent/plugin/filter_kubernetes_metadata.rb#L175-L187) where IPv6 is handled properly.