### PR TITLE
chore: upgrade Fluentd to v1.15.3

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-ruby@v1.1.3
         with:
-          ruby-version: '2.6'
+          ruby-version: '3.1'
       - name: Install bundler
         run: gem install bundler
       - name: Test fluent-plugin-datapoint
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-ruby@v1.1.3
         with:
-          ruby-version: '2.6'
+          ruby-version: '3.1'
       - name: Install bundler
         run: gem install bundler
       - name: Test fluent-plugin-enhance-k8s-metadata
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-ruby@v1.1.3
         with:
-          ruby-version: '2.6'
+          ruby-version: '3.1'
       - name: Install bundler
         run: gem install bundler
       - name: Test fluent-plugin-events
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-ruby@v1.1.3
         with:
-          ruby-version: '2.6'
+          ruby-version: '3.1'
       - name: Install bundler
         run: gem install bundler
       - name: Test fluent-plugin-kubernetes-metadata-filter
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-ruby@v1.1.3
         with:
-          ruby-version: '2.6'
+          ruby-version: '3.1'
       - name: Install bundler
         run: gem install bundler
       - name: Test fluent-plugin-kubernetes-sumologic
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-ruby@v1.1.3
         with:
-          ruby-version: '2.6'
+          ruby-version: '3.1'
       - name: Install bundler
         run: gem install bundler
       - name: Test fluent-plugin-prometheus-format
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-ruby@v1.1.3
         with:
-          ruby-version: '2.6'
+          ruby-version: '3.1'
       - name: Install bundler
         run: gem install bundler
       - name: Test fluent-plugin-protobuf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,17 @@
 # Contributing Guide
 
+## Testing your changes
+
+After making the necessary changes, run the following commands to test that your changes work correctly.
+
+```sh
+make test
+make build
+make image-test
+make build-alpine
+make image-test-alpine
+```
+
 ## Regenerating Gemfile
 
 Run the following command in order to generate `Gemfile.lock` files for the specific plugin:

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ REPO_URL = $(ECR_URL)/$(IMAGE_NAME)
 PLUGINS = $(wildcard fluent-plugin*)
 BUILD_PLUGINS = $(patsubst fluent-plugin%, build-fluent-plugin%, $(PLUGINS))
 TEST_PLUGINS = $(patsubst fluent-plugin%, test-fluent-plugin%, $(PLUGINS))
+BUNDLE_UPDATE_ALL = $(patsubst fluent-plugin%, bundle-update-fluent-plugin%, $(PLUGINS))
 
 build:
 	DOCKER_BUILDKIT=1 docker build \
@@ -79,3 +80,10 @@ _build-%:
 	( cd $* && bundle install --no-deployment )
 
 ${BUILD_PLUGINS}: build-%: _build-%
+
+.PHONY: bundle-update
+bundle-update: ${BUNDLE_UPDATE_ALL}
+
+.PHONY: bundle-update-%
+bundle-update-%:
+	(cd $* && bundle update --bundler)

--- a/ci/build-push-multiplatform.sh
+++ b/ci/build-push-multiplatform.sh
@@ -29,7 +29,7 @@ readonly arm_pid=$!
 docker buildx build \
     --push \
     --platform=linux/arm64/v8 \
-    --build-arg FLUENTD_ARCH="-arm64" \
+    --build-arg FLUENTD_ARCH="" \
     --build-arg BUILD_TAG="${BUILD_TAG}" \
     --tag "${REPO_URL}:${BUILD_TAG}-arm64" \
     . &

--- a/fluent-plugin-datapoint/.bundle/config
+++ b/fluent-plugin-datapoint/.bundle/config
@@ -1,2 +1,1 @@
 ---
-BUNDLE_FROZEN: "true"

--- a/fluent-plugin-datapoint/Gemfile.lock
+++ b/fluent-plugin-datapoint/Gemfile.lock
@@ -2,19 +2,19 @@ PATH
   remote: .
   specs:
     fluent-plugin-datapoint (2.0.0)
-      fluentd (= 1.14.6)
+      fluentd (= 1.15.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
     concurrent-ruby (1.1.10)
     cool.io (1.7.1)
-    fluentd (1.14.6)
+    fluentd (1.15.3)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.9.0)
       msgpack (>= 1.3.1, < 2.0.0)
-      serverengine (>= 2.2.5, < 3.0.0)
+      serverengine (>= 2.3.0, < 3.0.0)
       sigdump (~> 0.2.2)
       strptime (>= 0.2.4, < 1.0.0)
       tzinfo (>= 1.0, < 3.0)
@@ -22,18 +22,18 @@ GEM
       webrick (>= 1.4.2, < 1.8.0)
       yajl-ruby (~> 1.0)
     http_parser.rb (0.8.0)
-    msgpack (1.5.1)
-    power_assert (2.0.2)
+    msgpack (1.6.0)
+    power_assert (2.0.3)
     rake (13.0.6)
-    serverengine (2.2.5)
+    serverengine (2.3.1)
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
     strptime (0.2.5)
     test-unit (3.5.7)
       power_assert
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2022.1)
+    tzinfo-data (1.2022.7)
       tzinfo (>= 1.0.0)
     webrick (1.7.0)
     yajl-ruby (1.4.3)
@@ -48,4 +48,4 @@ DEPENDENCIES
   test-unit (~> 3.0)
 
 BUNDLED WITH
-   2.2.33
+   2.4.1

--- a/fluent-plugin-datapoint/fluent-plugin-datapoint.gemspec
+++ b/fluent-plugin-datapoint/fluent-plugin-datapoint.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
-  spec.add_runtime_dependency "fluentd", "= 1.14.6"
+  spec.add_runtime_dependency "fluentd", "= 1.15.3"
 end

--- a/fluent-plugin-enhance-k8s-metadata/.bundle/config
+++ b/fluent-plugin-enhance-k8s-metadata/.bundle/config
@@ -1,2 +1,1 @@
 ---
-BUNDLE_FROZEN: "true"

--- a/fluent-plugin-enhance-k8s-metadata/Gemfile.lock
+++ b/fluent-plugin-enhance-k8s-metadata/Gemfile.lock
@@ -14,7 +14,7 @@ PATH
   specs:
     fluent-plugin-enhance-k8s-metadata (2.0.0)
       concurrent-ruby (~> 1.1)
-      fluentd (= 1.14.6)
+      fluentd (= 1.15.3)
       lru_redux (~> 1.1.0)
       net-http-persistent (~> 4.0)
 
@@ -59,12 +59,12 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    fluentd (1.14.6)
+    fluentd (1.15.3)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.9.0)
       msgpack (>= 1.3.1, < 2.0.0)
-      serverengine (>= 2.2.5, < 3.0.0)
+      serverengine (>= 2.3.0, < 3.0.0)
       sigdump (~> 0.2.2)
       strptime (>= 0.2.4, < 1.0.0)
       tzinfo (>= 1.0, < 3.0)
@@ -94,7 +94,7 @@ GEM
     recursive-open-struct (1.1.3)
     rexml (3.2.5)
     ruby2_keywords (0.0.5)
-    serverengine (2.2.5)
+    serverengine (2.3.1)
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
     strptime (0.2.5)
@@ -126,4 +126,4 @@ DEPENDENCIES
   webmock (~> 3.0)
 
 BUNDLED WITH
-   2.3.14
+   2.4.1

--- a/fluent-plugin-enhance-k8s-metadata/fluent-plugin-enhance-k8s-metadata.gemspec
+++ b/fluent-plugin-enhance-k8s-metadata/fluent-plugin-enhance-k8s-metadata.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.1'
-  spec.add_runtime_dependency "fluentd", "= 1.14.6"
+  spec.add_runtime_dependency "fluentd", "= 1.15.3"
   # spec.add_runtime_dependency 'kubeclient', '4.9.1' # Git version of Kubeclient specified in Gemfile
   spec.add_runtime_dependency 'lru_redux', '~> 1.1.0'
   spec.add_runtime_dependency 'net-http-persistent', '~> 4.0'

--- a/fluent-plugin-events/.bundle/config
+++ b/fluent-plugin-events/.bundle/config
@@ -1,2 +1,1 @@
 ---
-BUNDLE_FROZEN: "true"

--- a/fluent-plugin-events/Gemfile.lock
+++ b/fluent-plugin-events/Gemfile.lock
@@ -13,7 +13,7 @@ PATH
   remote: .
   specs:
     fluent-plugin-events (2.0.0)
-      fluentd (= 1.14.6)
+      fluentd (= 1.15.3)
       net-http-persistent (~> 4.0)
 
 GEM
@@ -57,12 +57,12 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    fluentd (1.14.6)
+    fluentd (1.15.3)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.9.0)
       msgpack (>= 1.3.1, < 2.0.0)
-      serverengine (>= 2.2.5, < 3.0.0)
+      serverengine (>= 2.3.0, < 3.0.0)
       sigdump (~> 0.2.2)
       strptime (>= 0.2.4, < 1.0.0)
       tzinfo (>= 1.0, < 3.0)
@@ -93,7 +93,7 @@ GEM
     recursive-open-struct (1.1.3)
     rexml (3.2.5)
     ruby2_keywords (0.0.5)
-    serverengine (2.2.5)
+    serverengine (2.3.1)
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
     strptime (0.2.5)
@@ -126,4 +126,4 @@ DEPENDENCIES
   webmock (~> 3.0)
 
 BUNDLED WITH
-   2.3.14
+   2.4.1

--- a/fluent-plugin-events/fluent-plugin-events.gemspec
+++ b/fluent-plugin-events/fluent-plugin-events.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
-  spec.add_runtime_dependency "fluentd", "= 1.14.6"
+  spec.add_runtime_dependency "fluentd", "= 1.15.3"
   # spec.add_runtime_dependency 'kubeclient', '4.9.1' # Git version of Kubeclient specified in Gemfile
   spec.add_runtime_dependency 'net-http-persistent', '~> 4.0'
   spec.add_development_dependency 'webmock', '~> 3.0'

--- a/fluent-plugin-kubernetes-metadata-filter/.bundle/config
+++ b/fluent-plugin-kubernetes-metadata-filter/.bundle/config
@@ -1,2 +1,1 @@
 ---
-BUNDLE_FROZEN: "true"

--- a/fluent-plugin-kubernetes-metadata-filter/Gemfile.lock
+++ b/fluent-plugin-kubernetes-metadata-filter/Gemfile.lock
@@ -13,7 +13,7 @@ PATH
   remote: .
   specs:
     fluent-plugin-kubernetes-metadata-filter (2.5.3)
-      fluentd (= 1.14.6)
+      fluentd (= 1.15.3)
       lru_redux
       net-http-persistent (~> 4.0)
 
@@ -67,12 +67,12 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    fluentd (1.14.6)
+    fluentd (1.15.3)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.9.0)
       msgpack (>= 1.3.1, < 2.0.0)
-      serverengine (>= 2.2.5, < 3.0.0)
+      serverengine (>= 2.3.0, < 3.0.0)
       sigdump (~> 0.2.2)
       strptime (>= 0.2.4, < 1.0.0)
       tzinfo (>= 1.0, < 3.0)
@@ -179,4 +179,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   2.3.14
+   2.4.1

--- a/fluent-plugin-kubernetes-metadata-filter/fluent-plugin-kubernetes-metadata-filter.gemspec
+++ b/fluent-plugin-kubernetes-metadata-filter/fluent-plugin-kubernetes-metadata-filter.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.5.0'
 
-  gem.add_runtime_dependency "fluentd", "= 1.14.6"
+  gem.add_runtime_dependency "fluentd", "= 1.15.3"
   gem.add_runtime_dependency "lru_redux"
   # gem.add_runtime_dependency 'kubeclient', '< 5' # Git version of Kubeclient specified in Gemfile
   gem.add_runtime_dependency 'net-http-persistent', '~> 4.0'

--- a/fluent-plugin-kubernetes-sumologic/.bundle/config
+++ b/fluent-plugin-kubernetes-sumologic/.bundle/config
@@ -1,2 +1,1 @@
 ---
-BUNDLE_FROZEN: "true"

--- a/fluent-plugin-kubernetes-sumologic/Gemfile.lock
+++ b/fluent-plugin-kubernetes-sumologic/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     fluent-plugin-kubernetes-sumologic (2.0.0)
-      fluentd (= 1.14.6)
+      fluentd (= 1.15.3)
       httpclient (~> 2.8.0)
 
 GEM
@@ -17,12 +17,12 @@ GEM
     crack (0.4.5)
       rexml
     docile (1.4.0)
-    fluentd (1.14.6)
+    fluentd (1.15.3)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.9.0)
       msgpack (>= 1.3.1, < 2.0.0)
-      serverengine (>= 2.2.5, < 3.0.0)
+      serverengine (>= 2.3.0, < 3.0.0)
       sigdump (~> 0.2.2)
       strptime (>= 0.2.4, < 1.0.0)
       tzinfo (>= 1.0, < 3.0)
@@ -37,7 +37,7 @@ GEM
     public_suffix (2.0.5)
     rake (13.0.6)
     rexml (3.2.5)
-    serverengine (2.2.5)
+    serverengine (2.3.1)
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
     simplecov (0.21.2)
@@ -73,4 +73,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.4
+   2.4.1

--- a/fluent-plugin-kubernetes-sumologic/fluent-plugin-kubernetes-sumologic.gemspec
+++ b/fluent-plugin-kubernetes-sumologic/fluent-plugin-kubernetes-sumologic.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'test-unit', '~> 3.5.3'
   spec.add_development_dependency "codecov", ">= 0.1.10"
-  spec.add_runtime_dependency "fluentd", "= 1.14.6"
+  spec.add_runtime_dependency "fluentd", "= 1.15.3"
   spec.add_runtime_dependency 'httpclient', '~> 2.8.0'
 end

--- a/fluent-plugin-prometheus-format/.bundle/config
+++ b/fluent-plugin-prometheus-format/.bundle/config
@@ -1,2 +1,1 @@
 ---
-BUNDLE_FROZEN: "true"

--- a/fluent-plugin-prometheus-format/Gemfile.lock
+++ b/fluent-plugin-prometheus-format/Gemfile.lock
@@ -2,19 +2,19 @@ PATH
   remote: .
   specs:
     fluent-plugin-prometheus-format (2.0.0)
-      fluentd (= 1.14.6)
+      fluentd (= 1.15.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
     concurrent-ruby (1.1.10)
     cool.io (1.7.1)
-    fluentd (1.14.6)
+    fluentd (1.15.3)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.9.0)
       msgpack (>= 1.3.1, < 2.0.0)
-      serverengine (>= 2.2.5, < 3.0.0)
+      serverengine (>= 2.3.0, < 3.0.0)
       sigdump (~> 0.2.2)
       strptime (>= 0.2.4, < 1.0.0)
       tzinfo (>= 1.0, < 3.0)
@@ -25,7 +25,7 @@ GEM
     msgpack (1.5.1)
     power_assert (2.0.2)
     rake (13.0.6)
-    serverengine (2.2.5)
+    serverengine (2.3.1)
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
     strptime (0.2.5)
@@ -48,4 +48,4 @@ DEPENDENCIES
   test-unit (~> 3.0)
 
 BUNDLED WITH
-   2.3.4
+   2.4.1

--- a/fluent-plugin-prometheus-format/fluent-plugin-prometheus-format.gemspec
+++ b/fluent-plugin-prometheus-format/fluent-plugin-prometheus-format.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
-  spec.add_runtime_dependency "fluentd", "= 1.14.6"
+  spec.add_runtime_dependency "fluentd", "= 1.15.3"
 end

--- a/fluent-plugin-protobuf/.bundle/config
+++ b/fluent-plugin-protobuf/.bundle/config
@@ -1,2 +1,1 @@
 ---
-BUNDLE_FROZEN: "true"

--- a/fluent-plugin-protobuf/Gemfile.lock
+++ b/fluent-plugin-protobuf/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     fluent-plugin-protobuf (2.0.0)
-      fluentd (= 1.14.6)
+      fluentd (= 1.15.3)
       google-protobuf (~> 3.17)
       snappy (> 0)
 
@@ -11,12 +11,12 @@ GEM
   specs:
     concurrent-ruby (1.1.10)
     cool.io (1.7.1)
-    fluentd (1.14.6)
+    fluentd (1.15.3)
       bundler
       cool.io (>= 1.4.5, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.9.0)
       msgpack (>= 1.3.1, < 2.0.0)
-      serverengine (>= 2.2.5, < 3.0.0)
+      serverengine (>= 2.3.0, < 3.0.0)
       sigdump (~> 0.2.2)
       strptime (>= 0.2.4, < 1.0.0)
       tzinfo (>= 1.0, < 3.0)
@@ -25,19 +25,19 @@ GEM
       yajl-ruby (~> 1.0)
     google-protobuf (3.21.12)
     http_parser.rb (0.8.0)
-    msgpack (1.5.1)
-    power_assert (2.0.2)
+    msgpack (1.6.0)
+    power_assert (2.0.3)
     rake (13.0.6)
-    serverengine (2.2.5)
+    serverengine (2.3.1)
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
     snappy (0.3.0)
     strptime (0.2.5)
     test-unit (3.5.7)
       power_assert
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2022.1)
+    tzinfo-data (1.2022.7)
       tzinfo (>= 1.0.0)
     webrick (1.7.0)
     yajl-ruby (1.4.3)
@@ -52,4 +52,4 @@ DEPENDENCIES
   test-unit (~> 3.0)
 
 BUNDLED WITH
-   2.3.4
+   2.4.1

--- a/fluent-plugin-protobuf/fluent-plugin-protobuf.gemspec
+++ b/fluent-plugin-protobuf/fluent-plugin-protobuf.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit", "~> 3.0"
   spec.add_runtime_dependency "google-protobuf", "~> 3.17"
   spec.add_runtime_dependency "snappy", "> 0"
-  spec.add_runtime_dependency "fluentd", "= 1.14.6"
+  spec.add_runtime_dependency "fluentd", "= 1.15.3"
 end

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -22,6 +22,5 @@ usermod -aG docker vagrant
 apt-get install -y make
 
 # install requirements for ruby
-snap install ruby --channel=2.6/stable --classic
-su vagrant -c 'gem install bundler:2.1.4'
 apt install -y gcc g++ libsnappy-dev libicu-dev zlib1g-dev cmake pkg-config libssl-dev
+snap install ruby --stable --classic


### PR DESCRIPTION
This also upgrades:

- Ruby from v2.7 to v3.1
- Alpine from 3.14 to 3.16

and some other packages. See the Dockerfiles for details.