### PR TITLE
fix(ci): fix failing image builds

### DIFF
--- a/ci/build-push-multiplatform.sh
+++ b/ci/build-push-multiplatform.sh
@@ -39,10 +39,14 @@ wait $amd64_pid
 wait $arm_pid
 wait $arm64_pid
 
-docker manifest create --amend \
+docker buildx imagetools create --tag \
     "${REPO_URL}:${BUILD_TAG}" \
-    "${REPO_URL}:${BUILD_TAG}-amd64" \
-    "${REPO_URL}:${BUILD_TAG}-arm" \
-    "${REPO_URL}:${BUILD_TAG}-arm64"
+    "${REPO_URL}:${BUILD_TAG}-amd64"
 
-docker manifest push "${REPO_URL}:${BUILD_TAG}"
+docker buildx imagetools create --tag \
+    "${REPO_URL}:${BUILD_TAG}" \
+    "${REPO_URL}:${BUILD_TAG}-arm"
+
+docker buildx imagetools create --tag \
+    "${REPO_URL}:${BUILD_TAG}" \
+    "${REPO_URL}:${BUILD_TAG}-arm64"


### PR DESCRIPTION
The failing task already passed on https://github.com/SumoLogic/sumologic-kubernetes-fluentd/actions/runs/4565500819

The workflow corresponding to this branch: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/actions/runs/4565813000