### PR TITLE
fix(security): bump yajl-ruby to v1.4.3

### DIFF
--- a/fluent-plugin-kubernetes-sumologic/Gemfile.lock
+++ b/fluent-plugin-kubernetes-sumologic/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
-    yajl-ruby (1.4.2)
+    yajl-ruby (1.4.3)
 
 PLATFORMS
   ruby

--- a/fluent-plugin-kubernetes-sumologic/fluent-plugin-kubernetes-sumologic.gemspec
+++ b/fluent-plugin-kubernetes-sumologic/fluent-plugin-kubernetes-sumologic.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.executables   = []
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.0.0'
+  spec.required_ruby_version = '>= 2.7.0'
 
   spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Fixes vulnerability in yajl-ruby v1.4.2.

Refs: https://github.com/SumoLogic/sumologic-kubernetes-fluentd/security/dependabot/17